### PR TITLE
Implement Retrieve Profile API for General Use-cases

### DIFF
--- a/apps/v1/myauth/serializers.py
+++ b/apps/v1/myauth/serializers.py
@@ -87,3 +87,12 @@ class AuthTokenSerializer(serializers.Serializer):
         attrs['user'] = user
         return attrs
     
+class ProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Account
+        fields = (
+            'name',
+            'email',
+            'is_active',
+        )
+        

--- a/apps/v1/myauth/urls.py
+++ b/apps/v1/myauth/urls.py
@@ -4,5 +4,6 @@ from . import views
 urlpatterns = [
     path('users/<str:pk>/activate/', views.activate),
     path('users/<str:pk>/deactivate/', views.deactivate),
+    path('profile/', views.ProfileAPI.as_view()),
     path('token/', views.AuthToken.as_view()),
 ]

--- a/apps/v1/myauth/urls.py
+++ b/apps/v1/myauth/urls.py
@@ -4,6 +4,6 @@ from . import views
 urlpatterns = [
     path('users/<str:pk>/activate/', views.activate),
     path('users/<str:pk>/deactivate/', views.deactivate),
-    path('profile/', views.ProfileAPI.as_view()),
+    path('account/', views.AccountAPI.as_view()),
     path('token/', views.AuthToken.as_view()),
 ]

--- a/apps/v1/myauth/views.py
+++ b/apps/v1/myauth/views.py
@@ -100,7 +100,7 @@ class AuthToken(APIView):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-class ProfileAPI(APIView):
+class AccountAPI(APIView):
     serializer_class = ProfileSerializer
 
     def get(self, request, *args, **kwargs):

--- a/apps/v1/myauth/views.py
+++ b/apps/v1/myauth/views.py
@@ -10,7 +10,7 @@ from rest_framework_api_key.permissions import HasAPIAccess
 from apps.v1.common.tools import get_object_or_none, get_user_or_none
 from apps.v1.patient.permissions import AuthorityPermission
 from .models import Token
-from .serializers import AuthTokenSerializer
+from .serializers import AuthTokenSerializer, ProfileSerializer
 from .errors import TokenUnauthorizedError
 from .permissions import ActivationPermission
 
@@ -99,6 +99,15 @@ class AuthToken(APIView):
             token.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+class ProfileAPI(APIView):
+    serializer_class = ProfileSerializer
+
+    def get(self, request, *args, **kwargs):
+        user = get_user_or_none(request)
+
+        output_serializer = ProfileSerializer(user)
+        return Response(output_serializer.data)
 
 class UserViewSet(viewsets.ModelViewSet):
     lookup_value_regex = r'(.+)'


### PR DESCRIPTION
# Background
Currently, we split the profile API based on its role, and as we developed dashboard we found a trouble to show the profile in the dashboard because of these split APIs. To make it simple we generalize all the API into one API only that can be used by any roles.

## Changes
- [x] Implement profile API that can be used by any roles